### PR TITLE
Support for fluent-bit multiple config files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,8 +19,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Log into GitHub Container Registry
-      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
-        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
 
       - name: Build docker image
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,31 +12,7 @@ env:
   IMAGE_NAME: fluentd-sidecar-injector
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Log into GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-
-      - name: Build docker image
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-          SHA=${{ github.sha }}
-          docker build . --file Dockerfile --tag $IMAGE_ID:$SHA
-          docker push $IMAGE_ID:$SHA
-
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   e2e-test:
-    needs: build
-
     runs-on: ubuntu-latest
 
     steps:
@@ -44,18 +20,24 @@ jobs:
         with:
           go-version: '^1.15.0'
       - uses: actions/checkout@master
-      - uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: "v0.9.0"
+      - name: Setup kind
+        run: |
+          ./scripts/kind-with-registry.sh
       - name: Info
         run: |
           kubectl cluster-info
+      - name: Build docker image
+        run: |
+          IMAGE_ID=localhost:5000/$IMAGE_NAME
+          SHA=${{ github.sha }}
+          docker build . --file Dockerfile --tag $IMAGE_ID:$SHA
+          docker push $IMAGE_ID:$SHA
       - name: Install ginkgo
         run: |
           go get -u github.com/onsi/ginkgo/ginkgo
       - name: Testing
         run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          IMAGE_ID=localhost:5000/$IMAGE_NAME
           SHA=${{ github.sha }}
           export FLUENTD_SIDECAR_INJECTOR_IMAGE=$IMAGE_ID:$SHA
           go mod download

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -263,9 +263,7 @@ func injectFluentD(pod *corev1.Pod) (bool, error) {
 			if name := volumes[i].Name; name == value {
 				sidecar.VolumeMounts = append(sidecar.VolumeMounts, corev1.VolumeMount{
 					Name:      name,
-					MountPath: "/fluentd/etc/fluent.conf",
-					SubPath:   "fluent.conf",
-				})
+					MountPath: "/fluentd/etc" })
 				break
 			}
 		}

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -526,8 +526,7 @@ func injectFluentBit(pod *corev1.Pod) (bool, error) {
 			if name := volumes[i].Name; name == value {
 				sidecar.VolumeMounts = append(sidecar.VolumeMounts, corev1.VolumeMount{
 					Name:      name,
-					MountPath: "/fluent-bit/etc"
-				})
+					MountPath: "/fluent-bit/etc" })
 				break
 			}
 		}

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -526,8 +526,7 @@ func injectFluentBit(pod *corev1.Pod) (bool, error) {
 			if name := volumes[i].Name; name == value {
 				sidecar.VolumeMounts = append(sidecar.VolumeMounts, corev1.VolumeMount{
 					Name:      name,
-					MountPath: "/fluent-bit/etc/fluent-bit.conf",
-					SubPath:   "fluent-bit.conf",
+					MountPath: "/fluent-bit/etc"
 				})
 				break
 			}

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -190,7 +190,7 @@ func TestInjectFluentDDWithAnnotations(t *testing.T) {
 	if log := findMount(container.VolumeMounts, VolumeName); log.MountPath != "/var/log/nginx" {
 		t.Errorf("Container volume mount path is not matched: %v", log)
 	}
-	if config := findMount(container.VolumeMounts, "my-custom-volume"); config.MountPath != "/fluentd/etc/fluent.conf" {
+	if config := findMount(container.VolumeMounts, "my-custom-volume"); config.MountPath != "/fluentd/etc" {
 		t.Errorf("Container volume mount custom config is not matched: %#v", config)
 	}
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -439,7 +439,7 @@ func TestInjectFluentBitWithAnnotations(t *testing.T) {
 	if log := findMount(container.VolumeMounts, VolumeName); log.MountPath != "/var/log/nginx" {
 		t.Errorf("Container volume mount path is not matched: %v", log)
 	}
-	if config := findMount(container.VolumeMounts, "my-custom-config"); config.MountPath != "/fluent-bit/etc/fluent-bit.conf" {
+	if config := findMount(container.VolumeMounts, "my-custom-config"); config.MountPath != "/fluent-bit/etc" {
 		t.Errorf("Container volume mount custom config is not matched: %#v", config)
 	}
 }

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+## Please refer: https://kind.sigs.k8s.io/docs/user/local-registry/
+set -o errexit
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+EOF
+
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+


### PR DESCRIPTION
fluent-bit configuration has multiple configuration 
- Parser plugin configuration has to be provided as a separate file through `Parsers_File` option of the main config __[SERVICE]__ section 
- `@INCLUDE` option  allows also to split the main config file in multiple ones.

In order to support those, the ConfigMap cannot be mounted using `SubPath: fluent-bit.conf` but instead should be mounted on the `/fluent-bit/etc` parent directory for all config files provided in the map to be made available